### PR TITLE
Updated Gradle config for seamless import and load into Android Studio

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-all.zip


### PR DESCRIPTION
I wanted to play around with some of the sample projects for Glass.  I followed instructions here:

https://developers.google.com/glass/develop/gdk/quick-start#importing_samples

, I ran into error when importing from Git. Android Studio indicated that the sample project was using an outdated version of the Gradle plugin.

I made 3 simple updates according to recommendations here:

http://tools.android.com/tech-docs/new-build-system/migrating-to-1-0-0

And I was able to seamlessly import and run the samples.  If you think this is a good merge. I would be happy to do the same for the other samples.