### PR TITLE
Migrated gradle to more recent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ on the command line:
 
 To start the sample, say "ok glass, show me a demo" from the Glass clock
 screen or use the touch menu.
+
+## Notices for Linux users
+
+The Android SDK build tools ship outdated 32bit binaries in version
+20.0.0. Users of modern Linux kernels in 64bit mode might need to install
+additional libraries to run the build tools. In particular, this is:
+
+- `util-linux` (32bit)
+- `clang` (32bit)
+- `zstd` (32bit)
+- `zlib` (32bit)
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,12 @@
 
 buildscript {
     repositories {
+        google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
+        mavenCentral()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Even though I know that the Google Glass Explorer Edition SDK is officially discontinued, it might not be wrong to provide working examples for the few remaining enthusiasts out there.

I migrated the outdated Gradle versions to working ones which enables users to run the example with up-to-date versions of Android Studio.

Moreover, a notice on the 32bit binaries compiled for Linux 2.6 was added together with information on the required libraries to execute it on modern systems. The executable I was having the issue with is `$ANDROID_SDK/build-tools/20.0.0/aapt`.